### PR TITLE
feat: ollama llama3 api for auto context and embeddings generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The currently available options are:
 - `OpenAIEmbedding`
 - `CohereEmbedding`
 - `VoyageAIEmbedding`
+- `OllamaEmbedding`
 
 #### Reranker
 The Reranker components define the reranker. This is used after the vector database search (and before RSE) to provide a more accurate ranking of chunks.
@@ -116,6 +117,7 @@ This defines the LLM to be used for document summarization, which is only used i
 The currently available options are:
 - `OpenAIChatAPI`
 - `AnthropicChatAPI`
+- `OllamaChatAPI`
 
 ## Document upload flow
 Documents -> chunking -> embedding -> chunk and vector database upsert

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ langchain-text-splitters
 PyPDF2
 docx2txt
 pandas
+ollama

--- a/sprag/embedding.py
+++ b/sprag/embedding.py
@@ -129,10 +129,13 @@ class VoyageAIEmbedding(Embedding):
 
 
 class OllamaEmbedding(Embedding):
-    def __init__(self, model: str = "llama3", dimension: int = None):
+
+    def __init__(
+        self, model: str = "llama3", dimension: int = None, client: ollama.Client = None
+    ):
         super().__init__(dimension)
         self.model = model
-        self.client = ollama.Client()
+        self.client = client or ollama.Client()
         ollama.pull(model)
 
         if dimension is None:

--- a/sprag/embedding.py
+++ b/sprag/embedding.py
@@ -14,6 +14,10 @@ dimensionality = {
     "voyage-large-2": 1536,
     "voyage-law-2": 1024,
     "voyage-code-2": 1536,
+    "llama2": 4096,
+    "llama3": 4096,
+    "all-minilm": 384,
+    "nomic-embed-text": 768,
 }
 
 class Embedding(ABC):
@@ -125,11 +129,21 @@ class VoyageAIEmbedding(Embedding):
 
 
 class OllamaEmbedding(Embedding):
-    def __init__(self, model: str = "llama3", dimension: int = 4096):
+    def __init__(self, model: str = "llama3", dimension: int = None):
         super().__init__(dimension)
         self.model = model
         self.client = ollama.Client()
         ollama.pull(model)
+
+        if dimension is None:
+            try:
+                self.dimension = dimensionality[model]
+            except KeyError:
+                raise ValueError(
+                    f"Dimension for model {model} is unknown. Please provide the dimension manually."
+                )
+        else:
+            self.dimension = dimension
 
     def get_embeddings(self, text, input_type=None):
         if isinstance(text, list):

--- a/sprag/embedding.py
+++ b/sprag/embedding.py
@@ -120,7 +120,8 @@ class VoyageAIEmbedding(Embedding):
         base_dict.update({
             'model': self.model
         })
-        return base_dictclass OllamaEmbedding(Embedding):
+        base_dict.update({"model": self.model})
+        return base_dict
 
 
 class OllamaEmbedding(Embedding):

--- a/sprag/embedding.py
+++ b/sprag/embedding.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from openai import OpenAI
 import cohere
 import voyageai
+import ollama
 
 
 dimensionality = {
@@ -119,4 +120,28 @@ class VoyageAIEmbedding(Embedding):
         base_dict.update({
             'model': self.model
         })
+        return base_dictclass OllamaEmbedding(Embedding):
+
+
+class OllamaEmbedding(Embedding):
+    def __init__(self, model: str = "llama3", dimension: int = 4096):
+        super().__init__(dimension)
+        self.model = model
+        self.client = ollama.Client()
+        ollama.pull(model)
+
+    def get_embeddings(self, text, input_type=None):
+        if isinstance(text, list):
+            responses = []
+            for text in text:
+                response = self.client.embeddings(model=self.model, prompt=text)
+                responses.append(response["embedding"])
+            return responses
+        else:
+            response = self.client.embeddings(model=self.model, prompt=text)
+            return response["embedding"]
+
+    def to_dict(self):
+        base_dict = super().to_dict()
+        base_dict.update({"model": self.model})
         return base_dict

--- a/sprag/llm.py
+++ b/sprag/llm.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 import os
+import ollama
+
 
 class LLM(ABC):
     subclasses = {}
@@ -93,4 +95,36 @@ class AnthropicChatAPI(LLM):
             'temperature': self.temperature,
             'max_tokens': self.max_tokens
         })
+        return base_dict
+
+class OllamaAPI(LLM):
+    def __init__(
+        self, model: str = "llama3", temperature: float = 0.2, max_tokens: int = 1000
+    ):
+        self.client = ollama.Client()  # Assuming default host
+        self.model = model
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        ollama.pull(self.model)
+
+    def make_llm_call(self, chat_messages: list[dict]) -> str:
+        response = self.client.chat(
+            model=self.model,
+            messages=chat_messages,
+            options={
+                "num_predict": self.max_tokens,
+                "temperature": self.temperature,
+            },
+        )
+        return response["message"]["content"].strip()
+
+    def to_dict(self):
+        base_dict = super().to_dict()
+        base_dict.update(
+            {
+                "model": self.model,
+                "temperature": self.temperature,
+                "max_tokens": self.max_tokens,
+            }
+        )
         return base_dict

--- a/sprag/llm.py
+++ b/sprag/llm.py
@@ -99,9 +99,9 @@ class AnthropicChatAPI(LLM):
 
 class OllamaAPI(LLM):
     def __init__(
-        self, model: str = "llama3", temperature: float = 0.2, max_tokens: int = 1000
+        self, model: str = "llama3", temperature: float = 0.2, max_tokens: int = 1000, client: ollama.Client = None
     ):
-        self.client = ollama.Client()  # Assuming default host
+        self.client = client or ollama.Client()
         self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens

--- a/tests/integration/test_save_and_load.py
+++ b/tests/integration/test_save_and_load.py
@@ -6,7 +6,7 @@ import unittest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
 from sprag.knowledge_base import KnowledgeBase
-from sprag.llm import OpenAIChatAPI
+from sprag.llm import OpenAIChatAPI, OllamaAPI
 from sprag.embedding import VoyageAIEmbedding
 
 class TestSaveAndLoad(unittest.TestCase):
@@ -18,7 +18,7 @@ class TestSaveAndLoad(unittest.TestCase):
         self.cleanup()
 
         # initialize a KnowledgeBase object
-        auto_context_model = OpenAIChatAPI(model="gpt-4-turbo")
+        auto_context_model = OllamaAPI(model="llama3")
         embedding_model = VoyageAIEmbedding(model="voyage-code-2")
         kb = KnowledgeBase(kb_id="test_kb", auto_context_model=auto_context_model, embedding_model=embedding_model, exists_ok=False)
 
@@ -26,7 +26,7 @@ class TestSaveAndLoad(unittest.TestCase):
         kb1 = KnowledgeBase(kb_id="test_kb")
 
         # verify that the KnowledgeBase object has the right parameters
-        self.assertEqual(kb1.auto_context_model.model, "gpt-4-turbo")
+        self.assertEqual(kb1.auto_context_model.model, "llama3")
         self.assertEqual(kb1.embedding_model.model, "voyage-code-2")
 
         # delete the KnowledgeBase object

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -1,9 +1,16 @@
 import sys
 import os
 import unittest
-sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
 
-from sprag.embedding import OpenAIEmbedding, CohereEmbedding, VoyageAIEmbedding, Embedding
+sys.path.append(os.path.join(os.path.dirname(__file__), "../.."))
+
+from sprag.embedding import (
+    OpenAIEmbedding,
+    CohereEmbedding,
+    VoyageAIEmbedding,
+    OllamaEmbedding,
+    Embedding,
+)
 
 
 class TestEmbedding(unittest.TestCase):
@@ -28,6 +35,14 @@ class TestEmbedding(unittest.TestCase):
         embedding_provider = VoyageAIEmbedding(model)
         embedding = embedding_provider.get_embeddings(input_text, input_type="query")
         self.assertEqual(len(embedding), 1536)
+
+    def test__get_embeddings_ollama(self):
+        input_text = "Hello, world!"
+        model = "llama3"
+        dimension = 4096
+        embedding_provider = OllamaEmbedding(model, dimension)
+        embedding = embedding_provider.get_embeddings(input_text)
+        self.assertEqual(len(embedding), dimension)
 
     def test__get_embeddings_openai_with_list(self):
         input_texts = ["Hello, world!", "Goodbye, world!"]
@@ -55,6 +70,15 @@ class TestEmbedding(unittest.TestCase):
         embeddings = embedding_provider.get_embeddings(input_texts, input_type="query")
         self.assertEqual(len(embeddings), 2)
         self.assertTrue(all(len(embed) == 1536 for embed in embeddings))
+
+    def test__get_embeddings_ollama_with_list(self):
+        input_texts = ["Hello, world!", "Goodbye, world!"]
+        model = "llama2"
+        dimension = 4096
+        embedding_provider = OllamaEmbedding(model, dimension)
+        embeddings = embedding_provider.get_embeddings(input_texts)
+        self.assertEqual(len(embeddings), 2)
+        self.assertTrue(all(len(embed) == dimension for embed in embeddings))
 
     def test__initialize_from_config(self):
         config = {

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -71,10 +71,28 @@ class TestEmbedding(unittest.TestCase):
         self.assertEqual(len(embeddings), 2)
         self.assertTrue(all(len(embed) == 1536 for embed in embeddings))
 
-    def test__get_embeddings_ollama_with_list(self):
+    def test__get_embeddings_ollama_with_list_llama2(self):
         input_texts = ["Hello, world!", "Goodbye, world!"]
         model = "llama2"
         dimension = 4096
+        embedding_provider = OllamaEmbedding(model, dimension)
+        embeddings = embedding_provider.get_embeddings(input_texts)
+        self.assertEqual(len(embeddings), 2)
+        self.assertTrue(all(len(embed) == dimension for embed in embeddings))
+
+    def test__get_embeddings_ollama_with_list_minilm(self):
+        input_texts = ["Hello, world!", "Goodbye, world!"]
+        model = "all-minilm"
+        dimension = 384
+        embedding_provider = OllamaEmbedding(model, dimension)
+        embeddings = embedding_provider.get_embeddings(input_texts)
+        self.assertEqual(len(embeddings), 2)
+        self.assertTrue(all(len(embed) == dimension for embed in embeddings))
+
+    def test__get_embeddings_ollama_with_list_nomic(self):
+        input_texts = ["Hello, world!", "Goodbye, world!"]
+        model = "nomic-embed-text"
+        dimension = 768
         embedding_provider = OllamaEmbedding(model, dimension)
         embeddings = embedding_provider.get_embeddings(input_texts)
         self.assertEqual(len(embeddings), 2)

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -1,8 +1,9 @@
 import os
 import sys
 import unittest
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
-from sprag.llm import OpenAIChatAPI, AnthropicChatAPI, LLM
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from sprag.llm import OpenAIChatAPI, AnthropicChatAPI, OllamaAPI, LLM
 
 
 class TestLLM(unittest.TestCase):
@@ -19,6 +20,15 @@ class TestLLM(unittest.TestCase):
         chat_api = AnthropicChatAPI()
         chat_messages = [
             {"role": "user", "content": "What's the weather like today?"},
+        ]
+        response = chat_api.make_llm_call(chat_messages)
+        self.assertIsInstance(response, str)
+        self.assertGreater(len(response), 0)
+
+    def test__ollama_api(self):
+        chat_api = OllamaAPI()
+        chat_messages = [
+            {"role": "user", "content": "Who's your daddy?"},
         ]
         response = chat_api.make_llm_call(chat_messages)
         self.assertIsInstance(response, str)


### PR DESCRIPTION
- Generate embeddings with Ollama via [ollama-python](https://github.com/ollama/ollama-python)
  - Defaults to [`llama3`](https://ollama.com/library/llama3:8b) with dimension length `4096` (can also use `llama2`)
  - Can also use [`all-minilm`](https://ollama.com/library/all-minilm) (sentence-transformers) with dimension length `384` and max context length `256`
  - Can also use [`nomic-embed-text`](https://ollama.com/library/nomic-embed-text) with dimension length `768` and context length `8192`
- Generate llm api responses with Ollama via [ollama-python](https://github.com/ollama/ollama-python)
  - Defaults to [`llama3`](https://ollama.com/library/llama3:8b)
- Added tests for new classes

Requires installation of https://github.com/ollama/ollama

resolves https://github.com/SuperpoweredAI/spRAG/issues/5
resolves https://github.com/SuperpoweredAI/spRAG/issues/6