### PR TITLE
fix: OllamaAPI use client object when pulling model

### DIFF
--- a/sprag/llm.py
+++ b/sprag/llm.py
@@ -105,7 +105,7 @@ class OllamaAPI(LLM):
         self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
-        ollama.pull(self.model)
+        self.client.pull(self.model)
 
     def make_llm_call(self, chat_messages: list[dict]) -> str:
         response = self.client.chat(


### PR DESCRIPTION
`OllamaAPI` allows a `ollama.Client` object to be passed in, but uses the ollama default client to pull the model in the constructor.