### PR TITLE
fix: BasicVectorDB to_dict() saves value of use_faiss

### DIFF
--- a/sprag/vector_db.py
+++ b/sprag/vector_db.py
@@ -139,5 +139,5 @@ class BasicVectorDB(VectorDB):
             **super().to_dict(),
             'kb_id': self.kb_id,
             'storage_directory': self.storage_directory,
-            'use_faiss': False,
+            'use_faiss': self.use_faiss,
         }


### PR DESCRIPTION
When a kb is serialized/deserialized, the loaded vector db's `use_faiss` field is reset to `False`.